### PR TITLE
Use GET payment endpoint to validate order instead of auth.

### DIFF
--- a/controllers/main.py
+++ b/controllers/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 import json
 import logging
 import requests
@@ -9,6 +8,8 @@ import werkzeug
 
 from odoo import http, _
 from odoo.http import request
+
+from odoo.addons.payment.models.payment_acquirer import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -18,9 +19,10 @@ class NeloController(http.Controller):
 
     def _nelo_auth_payment(self, **params):
         acquirer = request.env['payment.acquirer'].sudo().search([('provider', '=', 'nelo')])
-        payload = json.dumps({
-            'checkoutToken': params['checkoutToken']
-        })
+
+        reference = params['reference']
+        orderUuid = params['orderUuid']
+
         headers = {
             'Authorization': 'Bearer %s' % (acquirer.nelo_merchant_secret),
             'Content-Type': 'application/json',
@@ -28,44 +30,37 @@ class NeloController(http.Controller):
             'x-app-version-code': '1'
         }
         try:
-            url = '%s/payments' % (acquirer._get_nelo_urls()['rest_url'])
-            authResponse = requests.request("POST", url, headers=headers, data=payload)
+            url = '%s/payments/%s' % (acquirer._get_nelo_urls()['rest_url'], orderUuid)
+            getPaymentResponse = requests.request("GET", url, headers=headers)
             _logger.info('Nelo - url requested %s' % url)
-            _logger.info('Nelo - response: %s' % authResponse)
-            authResponse.raise_for_status()
-            authJsonResponse = authResponse.json()
-            url = '%s/payments/%s/capture' % (acquirer._get_nelo_urls()['rest_url'], authJsonResponse['uuid'])
+            _logger.info('Nelo - response: %s' % getPaymentResponse)
+
+            getPaymentResponse.raise_for_status()
+            getPaymentJsonResponse = getPaymentResponse.json()
+
+            if getPaymentJsonResponse['reference'] != reference:
+                raise ValidationError(_('Nelo: received data with incorrect reference (%s)') % (reference))
+
+            url = '%s/payments/%s/capture' % (acquirer._get_nelo_urls()['rest_url'], orderUuid)
             captureResponse = requests.request("POST", url, headers=headers)
             _logger.info('Nelo - url requested %s' % url)
             _logger.info('Nelo - response: %s' % captureResponse)
             captureResponse.raise_for_status()
         except:
-            claims = self._get_claims(params['checkoutToken'])
-            if claims.get('reference'):
-                request.env['payment.transaction'].sudo().search(
-                    [('reference', '=', claims.get('reference'))]
-                )._set_transaction_error(_('Request rejected by Nelo.'))
+            request.env['payment.transaction'].sudo().search(
+                [('reference', '=', reference)]
+            )._set_transaction_error(_('Request rejected by Nelo.'))
             return False
         
         data = {
-            'reference': authJsonResponse['reference']
+            'reference': reference
         }
         return request.env['payment.transaction'].sudo().form_feedback(data, 'nelo')
-    
-    def _get_claims(self, checkoutToken):
-        try:
-            claims_base64 = checkoutToken.split(".")[1]
-            claims_base64 += "=" * ((4 - len(claims_base64) % 4) % 4) # add padding
-            claims_bytes = base64.b64decode(claims_base64, validate=False)
-            return json.loads(claims_bytes.decode('ascii'))
-        except:
-            _logger.info('Nelo - error %s' % err)
-            return json.loads('{}')
-        
+
 
     @http.route('/payment/nelo/confirm', type='http', auth="public", methods=['GET'], csrf=False)
     def nelo_return(self, **query_params):
-        if query_params and query_params['checkoutToken']:
+        if query_params and query_params['orderUuid'] and query_params['reference']:
             self._nelo_auth_payment(**query_params)
         return werkzeug.utils.redirect('/payment/process')
 


### PR DESCRIPTION
To verify that the order uuid matches the reference string,
we call the GET /payments/{uuid} endpoint. Once the reference
is confirmed to match what we got from the checkout flow,
we can capture the payment.